### PR TITLE
java.lang.UnsupportedOperationException fix

### DIFF
--- a/src/mire/commands.clj
+++ b/src/mire/commands.clj
@@ -60,7 +60,7 @@
   "See what you've got."
   []
   (str "You are carrying:\n"
-       (join "\n"  @*inventory*)))
+       (join "\n" (seq @*inventory*))))
 
 (defn detect
   "If you have the detector, you can see which room an item is in."


### PR DESCRIPTION
I was getting a "java.lang.UnsupportedOperationException: nth not supported on this type: PersistentHashSet" error when trying to run inventory - seq-ing the inventory reference fixes this.
