### PR TITLE
Fix test-execute by wrapping *err* Writer in a PrintWriter

### DIFF
--- a/src/mire/commands.clj
+++ b/src/mire/commands.clj
@@ -112,5 +112,5 @@
   (try (let [[command & args] (.split input " +")]
          (apply (commands command) args))
        (catch Exception e
-         (.printStackTrace e *err*)
+         (.printStackTrace e (new java.io.PrintWriter *err*))
          "You can't do that!")))

--- a/src/mire/server.clj
+++ b/src/mire/server.clj
@@ -23,7 +23,8 @@
 
 (defn- mire-handle-client [in out]
   (binding [*in* (reader in)
-            *out* (writer out)]
+            *out* (writer out)
+            *err* (writer System/err)]
 
     ;; We have to nest this in another binding call instead of using
     ;; the one above so *in* and *out* will be bound to the socket
@@ -40,6 +41,7 @@
       (try (loop [input (read-line)]
              (when input
                (println (execute input))
+               (.flush *err*)
                (print prompt) (flush)
                (recur (read-line))))
            (finally (cleanup))))))


### PR DESCRIPTION
I'm new to Clojure, so I might be doing something wrong, but when I pulled down the code and ran the tests, test-execute was failing with the error "No matching method found: printStackTrace for class java.lang.IllegalArgumentException" (full error is pasted below). It looks like what was happening was that IllegalArgumentException.printStackTrace() was  was expecting a PrintWriter as an argument, but _err_ was a BufferedWriter, so the method wasn't being called correctly. The fix was just to wrap the _err_ Writer in a PrintWriter. I also had to explicitly bind System/err to _err_ in the client hander and flush on every loop to allow the error messages to still be printed in the server console because printStackTrace was now actually getting called with a PrintWriter. Again, I'm new, so I'm not sure if this was the correct way to fix this test, but it is passing now along with all the others and game play appears to be normal.

Thanks,
Ryan

/usr/local/bin/lein test
Testing test-commands
ERROR in (test-execute) (Reflector.java:77)
expected: (= "You can't do that!" (execute "discard a can of beans into the fridge"))
  actual: java.lang.IllegalArgumentException: No matching method found: printStackTrace for class java.lang.IllegalArgumentException
 at clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:77)
    clojure.lang.Reflector.invokeInstanceMethod (Reflector.java:28)
    mire.commands$execute.invoke (commands.clj:115)
    test_commands$fn__488$fn__489.invoke (test_commands.clj:22)
    test_commands/fn (test_commands.clj:20)
    clojure.test$test_var$fn__6131.invoke (test.clj:688)
    clojure.test$test_var.invoke (test.clj:688)
    clojure.test$test_all_vars$fn__6135$fn__6142.invoke (test.clj:704)
    clojure.test$default_fixture.invoke (test.clj:658)
    clojure.test$test_all_vars$fn__6135.invoke (test.clj:704)
    clojure.test$default_fixture.invoke (test.clj:658)
    clojure.test$test_all_vars.invoke (test.clj:700)
    clojure.test$test_ns.invoke (test.clj:723)
    clojure.core$map$fn__3695.invoke (core.clj:2096)
    clojure.lang.LazySeq.sval (LazySeq.java:42)
    clojure.lang.LazySeq.seq (LazySeq.java:56)
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.boundedLength (RT.java:1186)
    clojure.lang.RestFn.applyTo (RestFn.java:131)
    clojure.core$apply.invoke (core.clj:542)
    clojure.test$run_tests.doInvoke (test.clj:738)
    clojure.lang.RestFn.applyTo (RestFn.java:138)
    clojure.core$apply.invoke (core.clj:540)
    user$eval29$fn__41.invoke (NO_SOURCE_FILE:1)
    user$eval29.invoke (NO_SOURCE_FILE:1)
    clojure.lang.Compiler.eval (Compiler.java:5424)
    clojure.lang.Compiler.eval (Compiler.java:5415)
    clojure.lang.Compiler.eval (Compiler.java:5391)
    clojure.core$eval.invoke (core.clj:2382)
    clojure.main$eval_opt.invoke (main.clj:235)
    clojure.main$initialize.invoke (main.clj:254)
    clojure.main$null_opt.invoke (main.clj:279)
    clojure.main$main.doInvoke (main.clj:354)
    clojure.lang.RestFn.invoke (RestFn.java:422)
    clojure.lang.Var.invoke (Var.java:369)
    clojure.lang.AFn.applyToHelper (AFn.java:165)
    clojure.lang.Var.applyTo (Var.java:482)
    clojure.main.main (main.java:37)
Testing test-rooms
Ran 8 tests containing 28 assertions.
0 failures, 1 errors.
